### PR TITLE
Add GitHub Actions for validation and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Generate changelog
+        id: git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          bodyFile: ${{ steps.git-cliff.outputs.changelog }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,40 @@
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
+
+{% for commit in commits %}
+{%- set title = commit.message | split(pat="\n") | first | trim | split(pat=" (#") | first -%}
+{%- if commit.scope -%}
+{%- set clean_title = title | split(pat="(" ~ commit.scope ~ ")") | last | trim | trim_start_matches(pat=":") | trim -%}
+- [`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/couchbaselabs/topology-ui/commit/{{ commit.id }}) - **{{ commit.scope }}**: {{ clean_title }}{% if commit.remote.pr_number and commit.remote.username %} *(PR [#{{ commit.remote.pr_number }}](https://github.com/couchbaselabs/topology-ui/pull/{{ commit.remote.pr_number }}) by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}))*{% elif commit.remote.pr_number %} *(PR [#{{ commit.remote.pr_number }}](https://github.com/couchbaselabs/topology-ui/pull/{{ commit.remote.pr_number }}))*{% elif commit.remote.username %} *(commit by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}))*{% elif commit.author.name %} *(commit by {{ commit.author.name }})*{% endif %}
+{%- else -%}
+- [`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/couchbaselabs/topology-ui/commit/{{ commit.id }}) - {{ title }}{% if commit.remote.pr_number and commit.remote.username %} *(PR [#{{ commit.remote.pr_number }}](https://github.com/couchbaselabs/topology-ui/pull/{{ commit.remote.pr_number }}) by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}))*{% elif commit.remote.pr_number %} *(PR [#{{ commit.remote.pr_number }}](https://github.com/couchbaselabs/topology-ui/pull/{{ commit.remote.pr_number }}))*{% elif commit.remote.username %} *(commit by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}))*{% elif commit.author.name %} *(commit by {{ commit.author.name }})*{% endif %}
+{%- endif %}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+
+commit_parsers = [
+  { message = "^Merge ", skip = true },
+  { message = "(?i)(bucket|mobile|sync gateway|scope|scopes|collection|collections|connector|cluster topology)", group = "Features" },
+  { message = "(?i)(css|tailwind|font|style|styles|theme)", group = "Styling" },
+  { message = "(?i)(renderer|render|layout|host-safe|stacking context)", group = "Renderer" },
+  { message = "(?i)(refactor|cleanup|format|modularize)", group = "Maintenance" },
+  { message = "(?i)(npm|publish|package|release|changelog|cliff)", group = "Packaging & Release" },
+  { message = "(?i)(readme|docs?|documentation|sample)", group = "Documentation" },
+  { message = "(?i)\\b(test|tests)\\b", group = "Tests" },
+  { message = ".*", group = "Other Changes" },
+]
+
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"


### PR DESCRIPTION
This PR introduces:
- a `Validate` workflow that runs `npm test` on pushes to `main` and on pull requests
- a tag-driven release workflow for `v*` tags that runs tests, generates release notes with `git-cliff`, publishes to npm, and creates a GitHub release
- a `git-cliff` configuration tailored to this repo, including grouped release notes with commit and PR links

This sets up the basic CI/release path for publishing the package from GitHub.